### PR TITLE
Switched authentication to cloud-resource API key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The different contexts are:
 - manage clusters, topics, acls, etc.
 - manage data flows into / via topics.
 
-### 
+###
 First, a login to the web based interface and also usage of ccloud CLI requires the Confluent Cloud account credentials.
 With this, one can manage multiple environments and multiple clusters.
 The CCAccount typically is based on an email address.
@@ -19,22 +19,28 @@ We export the credentials for the Confluent Cloud account as variable `CCAccount
 ```
 
 Access to each cluster can be granted by an API key.
- 
-API key management is done in the web interface or using the Confluent Cloud commandline interface.
+
+API key management is done in the web interface or using the Confluent Cloud command line interface.
 
 The credentials to work with a particular cluster are given by an API key and the related secret.
+For the purpose of accessing the metrics API, one must create an API key for the cloud resource.
+This can be done via
+```bash
+ccloud api-key create --resource cloud
 ```
- export APIKEY_lkc-387om='KEY:SECRET'
+Why it is also possible to authenticate using username and password, authentication using an API key is preferred since API keys can be rotated easily.
+```
+ export APIKEY_CLOUD='KEY:SECRET'
 ```
 
 ## How to get a list of available metrics?
 ```
-  http -v https://api.telemetry.confluent.cloud/v1/metrics/cloud/descriptors --auth $CCAccount > list_of_metrics.json
+  http -v https://api.telemetry.confluent.cloud/v1/metrics/cloud/descriptors --auth $APIKEY_CLOUD > list_of_metrics.json
 ```
 
 ## How to query the metrics API?
 ```
-  http -v https://api.telemetry.confluent.cloud/v1/metrics/cloud/attributes --auth $CCAccount < q1.json
+  http -v https://api.telemetry.confluent.cloud/v1/metrics/cloud/attributes --auth $APIKEY_CLOUD < q1.json
 ```
 
 ## Which metrics are available via Confluent Cloud metrics API?
@@ -46,5 +52,3 @@ The credentials to work with a particular cluster are given by an API key and th
 ## Query examples:
 
 The official documentation provides some examples for retrieving aggregated metrics: https://docs.confluent.io/current/cloud/metrics-api.html.
-
-


### PR DESCRIPTION
As it is advisable to not login with username and password, the authentication
was switeched to use an API key generated with the --resource cloud flag.